### PR TITLE
Specify N from command line. Fix bugs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,22 @@ default: common.o simpleMemcpy simpleManaged gemmMemcpy gemmManaged gemmXtOutOfC
 
 
 simpleMemcpy: Makefile simpleMemcpy.cu common.o
-	$(NVCC) -o simpleMemcpy simpleMemcpy.cu common.o
+	$(NVCC) -o simpleMemcpy simpleMemcpy.cu common.o -DDEFAULT_N=1000000
 
 simpleManaged: Makefile simpleManaged.cu common.o
-	$(NVCC) -o simpleManaged simpleManaged.cu common.o
+	$(NVCC) -o simpleManaged simpleManaged.cu common.o -DDEFAULT_N=1000000
 
 gemmMemcpy: Makefile gemmMemcpy.cu common.o
-	$(NVCC) -o gemmMemcpy gemmMemcpy.cu common.o
+	$(NVCC) -o gemmMemcpy gemmMemcpy.cu common.o -DDEFAULT_N=1000
 
 gemmManaged: Makefile gemmManaged.cu common.o
-	$(NVCC) -o gemmManaged gemmManaged.cu common.o
+	$(NVCC) -o gemmManaged gemmManaged.cu common.o -DDEFAULT_N=1000
 
 gemmXtOutOfCore: Makefile gemmXtOutOfCore.cu common.o
-	$(NVCC) -o gemmXtOutOfCore gemmXtOutOfCore.cu common.o
+	$(NVCC) -o gemmXtOutOfCore gemmXtOutOfCore.cu common.o -DDEFAULT_N=2000
 
 gemmManagedOutOfCore: Makefile gemmManagedOutOfCore.cu common.o
-	$(NVCC) -o gemmManagedOutOfCore gemmManagedOutOfCore.cu common.o
+	$(NVCC) -o gemmManagedOutOfCore gemmManagedOutOfCore.cu common.o -DDEFAULT_N=2000
 
 common.o: Makefile common.cc common.hh
 	$(NVCC) -c common.cc

--- a/gemmManaged.cu
+++ b/gemmManaged.cu
@@ -5,11 +5,12 @@
 #include "common.hh"
 
 
-const size_t N = 16000;
-
-
-int main()
+int main(int argc, char *argv[])
 {
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
     clock_t start_program, end_program;
     clock_t start, end;
     cublasHandle_t handle;

--- a/gemmManagedOutOfCore.cu
+++ b/gemmManagedOutOfCore.cu
@@ -4,12 +4,12 @@
 #include <cublas.h>
 #include "common.hh"
 
-
-const size_t N = 32000;
-
-
-int main()
+int main(int argc, char *argv[])
 {
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
     clock_t start, end; 
     cublasHandle_t handle;
     float *a, *b, *c;

--- a/gemmMemcpy.cu
+++ b/gemmMemcpy.cu
@@ -5,11 +5,12 @@
 #include "common.hh"
 
 
-const size_t N = 16000;
-
-
-int main()
+int main(int argc, char *argv[])
 {
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
     clock_t start_program, end_program;
     clock_t start, end;
     cublasHandle_t handle;
@@ -42,7 +43,6 @@ int main()
 
     check(cudaMemcpy(da, a, count, cudaMemcpyHostToDevice));
     check(cudaMemcpy(db, b, count, cudaMemcpyHostToDevice));
-    check(cudaMemcpy(dc, c, count, cudaMemcpyHostToDevice));
 
     check(cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N,
                       N, N, N,
@@ -82,9 +82,9 @@ int main()
     log("host: access all arrays a second time", start, end);
 
     start = clock();
-    cudaFree(a);
-    cudaFree(b);
-    cudaFree(c);
+    cudaFreeHost(a);
+    cudaFreeHost(b);
+    cudaFreeHost(c);
     end = clock();
     log("host: free", start, end);
 

--- a/gemmXtOutOfCore.cu
+++ b/gemmXtOutOfCore.cu
@@ -5,11 +5,12 @@
 #include "common.hh"
 
 
-const size_t N = 32000;
-
-
-int main()
+int main(int argc, char *argv[])
 {
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
     clock_t start, end; 
     cublasXtHandle_t handle;
     int devices[1] = {0};

--- a/simpleManaged.cu
+++ b/simpleManaged.cu
@@ -4,9 +4,6 @@
 #include "common.hh"
 
 
-const size_t N = 500000000;
-
-
 static __global__ void
 f(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
 {
@@ -28,8 +25,12 @@ doit(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
 }
 
 int
-main(void)
+main(int argc, char *argv[])
 {
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
     clock_t start_program, end_program;
     clock_t start, end;
     uint64_t *a, *b, *c;
@@ -42,7 +43,7 @@ main(void)
     check(cudaMallocManaged(&b, count));
     check(cudaMallocManaged(&c, count));
     end = clock();
-    log("host: malloc", start, end);
+    log("host: MallocManaged", start, end);
 
     start = clock();
     for (size_t i = 0; i < N; i++) {

--- a/simpleMemcpy.cu
+++ b/simpleMemcpy.cu
@@ -1,10 +1,8 @@
 #include <cstdio>
+#include <cstdlib>
 #include <cinttypes>
 #include <cuda_runtime.h>
 #include "common.hh"
-
-
-const size_t N = 500000000;
 
 
 static __global__ void
@@ -28,8 +26,12 @@ doit(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
 }
 
 int
-main(void)
+main(int argc, char *argv[])
 {
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
     clock_t start_program, end_program;
     clock_t start, end;
     uint64_t *a, *b, *c;
@@ -43,7 +45,7 @@ main(void)
     check(cudaMallocHost(&b, count));
     check(cudaMallocHost(&c, count));
     end = clock();
-    log("host: malloc", start, end);
+    log("host: MallocHost", start, end);
 
     start = clock();
     for (size_t i = 0; i < N; i++) {
@@ -60,7 +62,6 @@ main(void)
 
     check(cudaMemcpy(da, a, count, cudaMemcpyHostToDevice));
     check(cudaMemcpy(db, b, count, cudaMemcpyHostToDevice));
-    check(cudaMemcpy(dc, c, count, cudaMemcpyHostToDevice));
 
     doit(da, db, dc, N);
 
@@ -95,9 +96,9 @@ main(void)
     log("host: access all arrays a second time", start, end);
 
     start = clock();
-    cudaFree(a);
-    cudaFree(b);
-    cudaFree(c);
+    cudaFreeHost(a);
+    cudaFreeHost(b);
+    cudaFreeHost(c);
     end = clock();
     log("host: free", start, end);
 


### PR DESCRIPTION
This PR implements:
1. Specify N from command line. Reduce the default N values as these were too big here and defaults should not cause crashes. But feel free to adjust the defaults.
2. Use cudaFreeHost for freeing memory allocated with cudaMallocHost
3. Remove unnecessary copy in cudaMemcpy benchmarks.

With these changes on Quadro P2000 (5GB) device the results are:

```
$ ./simpleManaged 5000000
N=5000000
host: MallocManaged: 0.259980
host: init arrays: 0.022115
device: uvm+compute+synchronize: 0.024375
host: access all arrays: 0.032107
host: access all arrays a second time: 0.006400
host: free: 0.007455
total: 0.352554
$ ./simpleMemcpy 5000000
N=5000000
host: MallocHost: 0.320333
host: init arrays: 0.006447
device: malloc+copy+compute: 0.016022
host: access all arrays: 0.006594
host: access all arrays a second time: 0.006936
host: free: 0.016564
total: 0.373044
```

```
$ ./gemmManaged 10000
N=10000
host: cudaMallocManaged+init: 0.414032
cublasSgemm: 1.004042
host: access all arrays: 0.000153
host: access all arrays a second time: 0.000026
host: free: 0.038956
total: 1.912736

$ ./gemmMemcpy 10000
N=10000
host: cudaMallocHost+init: 0.545684
cublasSgemm: 16.233048
host: access all arrays: 0.000015
host: access all arrays a second time: 0.000013
host: free: 0.156380
total: 17.392518
```

```
$ ./gemmManagedOutOfCore 10000
N=10000
host: cudaMallocManaged+init: 0.450139
cublasSgemm: 0.997049

$ ./gemmXtOutOfCore 10000
N=10000
host: cudaMallocHost+init: 0.538053
cublasXtSgemm: 0.990271
```