### PR TITLE
Add benchmark that uses host memory via DMA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,29 @@
 NVCC = nvcc --compiler-options="-Wall -Wextra -O3" -std=c++11 -arch=compute_61 -code=sm_61 -lcublas
 
 
-default: common.o simpleMemcpy simpleManaged gemmMemcpy gemmManaged gemmXtOutOfCore gemmManagedOutOfCore
+default: common.o simpleMemcpy simpleManaged simpleDMA gemmMemcpy gemmManaged gemmXtOutOfCore gemmManagedOutOfCore
 
 
 simpleMemcpy: Makefile simpleMemcpy.cu common.o
-	$(NVCC) -o simpleMemcpy simpleMemcpy.cu common.o
+	$(NVCC) -o simpleMemcpy simpleMemcpy.cu common.o -DDEFAULT_N=1000000
 
 simpleManaged: Makefile simpleManaged.cu common.o
-	$(NVCC) -o simpleManaged simpleManaged.cu common.o
+	$(NVCC) -o simpleManaged simpleManaged.cu common.o -DDEFAULT_N=1000000
+
+simpleDMA: Makefile simpleDMA.cu common.o
+	$(NVCC) -o simpleDMA simpleDMA.cu common.o -DDEFAULT_N=1000000
 
 gemmMemcpy: Makefile gemmMemcpy.cu common.o
-	$(NVCC) -o gemmMemcpy gemmMemcpy.cu common.o
+	$(NVCC) -o gemmMemcpy gemmMemcpy.cu common.o -DDEFAULT_N=1000
 
 gemmManaged: Makefile gemmManaged.cu common.o
-	$(NVCC) -o gemmManaged gemmManaged.cu common.o
+	$(NVCC) -o gemmManaged gemmManaged.cu common.o -DDEFAULT_N=1000
 
 gemmXtOutOfCore: Makefile gemmXtOutOfCore.cu common.o
-	$(NVCC) -o gemmXtOutOfCore gemmXtOutOfCore.cu common.o
+	$(NVCC) -o gemmXtOutOfCore gemmXtOutOfCore.cu common.o -DDEFAULT_N=2000
 
 gemmManagedOutOfCore: Makefile gemmManagedOutOfCore.cu common.o
-	$(NVCC) -o gemmManagedOutOfCore gemmManagedOutOfCore.cu common.o
+	$(NVCC) -o gemmManagedOutOfCore gemmManagedOutOfCore.cu common.o -DDEFAULT_N=2000
 
 common.o: Makefile common.cc common.hh
 	$(NVCC) -c common.cc

--- a/simpleDMA.cu
+++ b/simpleDMA.cu
@@ -1,0 +1,96 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cinttypes>
+#include <cuda_runtime.h>
+#include "common.hh"
+
+
+static __global__ void
+f(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
+{
+    int64_t index = threadIdx.x + blockIdx.x * blockDim.x;
+    int64_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = index; i < N; i += stride) {
+        c[i] = a[i] * b[i];
+    }
+}
+
+static void
+doit(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
+{
+    int blockSize = 256;
+    int64_t numBlocks = (N + blockSize - 1) / blockSize;
+
+    f<<<numBlocks, blockSize>>>(a, b, c, N);
+}
+
+int
+main(int argc, char *argv[])
+{
+    size_t N = DEFAULT_N;
+    if (argc==2) N = (size_t)atoi(argv[1]);
+    printf("N=%zd\n", N);
+
+    clock_t start_program, end_program;
+    clock_t start, end;
+    uint64_t *a, *b, *c;
+    size_t count = N * sizeof(uint64_t);
+
+    start_program = clock();
+
+    start = clock();
+    check(cudaMallocHost(&a, count));
+    check(cudaMallocHost(&b, count));
+    check(cudaMallocHost(&c, count));
+    end = clock();
+    log("host: MallocHost", start, end);
+
+    start = clock();
+    for (size_t i = 0; i < N; i++) {
+        a[i] = 3;
+        b[i] = 5;
+    }
+    end = clock();
+    log("host: init arrays", start, end);
+
+    start = clock();
+    doit(a, b, c, N);
+    check(cudaDeviceSynchronize());
+    end = clock();
+    log("device: MallocHost+compute", start, end);
+
+    start = clock();
+    for (size_t i = 0; i < N; i++) {
+        if (a[i] != 3 || b[i] != 5 || c[i] != 15) {
+            fprintf(stderr, "unexpected result a: %lu  b: %lu  c: %lu\n",
+                    a[i], b[i], c[i]);
+            exit(1);
+        }
+    }
+    end = clock();
+    log("host: access all arrays", start, end);
+
+    start = clock();
+    for (size_t i = 0; i < N; i++) {
+        if (a[i] != 3 || b[i] != 5 || c[i] != 15) {
+            fprintf(stderr, "unexpected result a: %lu  b: %lu  c: %lu\n",
+                    a[i], b[i], c[i]);
+            exit(1);
+        }
+    }
+    end = clock();
+    log("host: access all arrays a second time", start, end);
+
+    start = clock();
+    cudaFreeHost(a);
+    cudaFreeHost(b);
+    cudaFreeHost(c);
+    end = clock();
+    log("host: free", start, end);
+
+    end_program = clock();
+    log("total", start_program, end_program);
+
+    return 0;
+}


### PR DESCRIPTION
Compare this to PR #1 results:
```
$ ./simpleDMA 5000000
N=5000000
host: MallocHost: 0.318288
host: init arrays: 0.006203
device: MallocHost+compute: 0.010511
host: access all arrays: 0.006403
host: access all arrays a second time: 0.006301
host: free: 0.015551
total: 0.363371
```