### PR TITLE
Use Unified Memory with Prefetching Hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 NVCC = nvcc --compiler-options="-Wall -Wextra -O3" -std=c++11 -arch=compute_61 -code=sm_61 -lcublas
 
 
-default: common.o simpleMemcpy simpleManaged simpleDMA stridedManaged gemmMemcpy gemmManaged gemmXtOutOfCore gemmManagedOutOfCore
+default: common.o simpleMemcpy simpleManaged simpleManagedPrefetch simpleDMA stridedManaged gemmMemcpy gemmManaged gemmManagedPrefetch gemmXtOutOfCore gemmManagedOutOfCore
 
 
 simpleMemcpy: Makefile simpleMemcpy.cu common.o
@@ -11,6 +11,9 @@ simpleMemcpy: Makefile simpleMemcpy.cu common.o
 
 simpleManaged: Makefile simpleManaged.cu common.o
 	$(NVCC) -o simpleManaged simpleManaged.cu common.o
+
+simpleManagedPrefetch: Makefile simpleManagedPrefetch.cu common.o
+	$(NVCC) -o simpleManagedPrefetch simpleManagedPrefetch.cu common.o
 
 simpleDMA: Makefile simpleDMA.cu common.o
 	$(NVCC) -o simpleDMA simpleDMA.cu common.o
@@ -24,6 +27,9 @@ gemmMemcpy: Makefile gemmMemcpy.cu common.o
 gemmManaged: Makefile gemmManaged.cu common.o
 	$(NVCC) -o gemmManaged gemmManaged.cu common.o
 
+gemmManagedPrefetch: Makefile gemmManagedPrefetch.cu common.o
+	$(NVCC) -o gemmManagedPrefetch gemmManagedPrefetch.cu common.o
+
 gemmXtOutOfCore: Makefile gemmXtOutOfCore.cu common.o
 	$(NVCC) -o gemmXtOutOfCore gemmXtOutOfCore.cu common.o
 
@@ -35,4 +41,4 @@ common.o: Makefile common.cc common.hh
 
 
 clean:
-	rm -f common.o simpleMemcpy simpleManaged simpleDMA stridedManaged gemmMemcpy gemmManaged gemmXtOutOfCore gemmManagedOutOfCore
+	rm -f common.o simpleMemcpy simpleManaged simpleManagedPrefetch simpleDMA stridedManaged gemmMemcpy gemmManaged gemmManagedPrefetch gemmXtOutOfCore gemmManagedOutOfCore

--- a/simpleManagedPrefetch.cu
+++ b/simpleManagedPrefetch.cu
@@ -1,0 +1,107 @@
+#include <cstdio>
+#include <cinttypes>
+#include <cuda_runtime.h>
+#include "common.hh"
+
+
+static __global__ void
+f(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
+{
+    int64_t index = threadIdx.x + blockIdx.x * blockDim.x;
+    int64_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = index; i < N; i += stride) {
+        c[i] = a[i] * b[i];
+    }
+}
+
+static void
+doit(const uint64_t a[], const uint64_t b[], uint64_t c[], int64_t N)
+{
+    int blockSize = 256;
+    int64_t numBlocks = (N + blockSize - 1) / blockSize;
+
+    f<<<numBlocks, blockSize>>>(a, b, c, N);
+}
+
+int
+main(int argc, char *argv[])
+{
+    size_t N = 10000000;
+    clock_t start_program, end_program;
+    clock_t start, end;
+    uint64_t *a, *b, *c;
+    size_t count;
+
+    if (argc == 2) {
+        N = checked_strtosize(argv[1]);
+    }
+    count = checked_mul(N, sizeof(uint64_t));
+
+    /* Initialize context */
+    check(cudaMallocManaged(&a, 128));
+    check(cudaDeviceSynchronize());
+    check(cudaFree(a));
+
+    start_program = clock();
+
+    start = clock();
+    check(cudaMallocManaged(&a, count, cudaMemAttachHost));
+    check(cudaMallocManaged(&b, count, cudaMemAttachHost));
+    check(cudaMallocManaged(&c, count));
+    end = clock();
+    log("host: MallocManaged", start, end);
+
+    start = clock();
+    for (size_t i = 0; i < N; i++) {
+        a[i] = 3;
+        b[i] = 5;
+    }
+    end = clock();
+    log("host: init arrays", start, end);
+
+    start = clock();
+    check(cudaStreamAttachMemAsync(NULL, a, 0, cudaMemAttachGlobal));
+    check(cudaStreamAttachMemAsync(NULL, b, 0, cudaMemAttachGlobal));
+    doit(a, b, c, N);
+    check(cudaStreamAttachMemAsync(NULL, a, 0, cudaMemAttachHost));
+    check(cudaStreamAttachMemAsync(NULL, b, 0, cudaMemAttachHost));
+    check(cudaStreamAttachMemAsync(NULL, c, 0, cudaMemAttachHost));
+    check(cudaStreamSynchronize(NULL));
+    end = clock();
+    log("device: uvm+compute+synchronize", start, end);
+
+    start = clock();
+    for (size_t i = 0; i < N; i++) {
+        if (a[i] != 3 || b[i] != 5 || c[i] != 15) {
+            fprintf(stderr, "unexpected result a: %lu  b: %lu  c: %lu\n",
+                    a[i], b[i], c[i]);
+            exit(1);
+        }
+    }
+    end = clock();
+    log("host: access all arrays", start, end);
+
+    start = clock();
+    for (size_t i = 0; i < N; i++) {
+        if (a[i] != 3 || b[i] != 5 || c[i] != 15) {
+            fprintf(stderr, "unexpected result a: %lu  b: %lu  c: %lu\n",
+                    a[i], b[i], c[i]);
+            exit(1);
+        }
+    }
+    end = clock();
+    log("host: access all arrays a second time", start, end);
+
+    start = clock();
+    check(cudaFree(a));
+    check(cudaFree(b));
+    check(cudaFree(c));
+    end = clock();
+    log("host: free", start, end);
+
+    end_program = clock();
+    log("total", start_program, end_program);
+
+    return 0;
+}


### PR DESCRIPTION
Hi,

I'm tesing on Nvidia Jetson platform. Because the memory is shared between CPU and GPU, using pinned memory or unified memory are both zero-copy method.
[As suggested by Nvidia](https://docs.nvidia.com/cuda/cuda-for-tegra-appnote/index.html#effective-usage-unified-memory), unified memory is preferable over pinned memory on Jetson. The performance can be improved by providing data prefetching hints.
Here are the results tested on Jetson Nano.
```
jetbot@jetbot:~/cuda-benchmarks$ ./simpleMemcpy 40000000
host: MallocHost: 0.784903
host: init arrays: 0.441145
device: malloc+copy+compute: 0.849618
host: access all arrays: 5.792553
host: access all arrays a second time: 5.668659
host: free: 0.169375
total: 13.706508
jetbot@jetbot:~/cuda-benchmarks$ ./simpleDMA 40000000
host: MallocHost: 0.757304
host: init arrays: 0.444463
device: DMA+compute+synchronize: 0.000195
host: access all arrays: 5.858257
host: access all arrays a second time: 5.747822
host: free: 0.146583
total: 12.954863
jetbot@jetbot:~/cuda-benchmarks$ ./simpleManaged 40000000
host: MallocManaged: 0.752979
host: init arrays: 0.374388
device: uvm+compute+synchronize: 0.003553
host: access all arrays: 0.865331
host: access all arrays a second time: 0.457495
host: free: 0.147483
total: 2.601491
jetbot@jetbot:~/cuda-benchmarks$ ./simpleManagedPrefetch 40000000
host: MallocManaged: 1.133410
host: init arrays: 0.076782
device: uvm+compute+synchronize: 0.008097
host: access all arrays: 0.589185
host: access all arrays a second time: 0.451023
host: free: 0.148908
total: 2.407675
```
```
jetbot@jetbot:~/cuda-benchmarks$ ./gemmMemcpy 5000
host: MallocHost+init: 1.308709
cublasSgemm: 0.265773
host: access all arrays: 0.001682
host: access all arrays a second time: 0.001673
host: free: 0.048349
total: 2.168886
jetbot@jetbot:~/cuda-benchmarks$ ./gemmManaged 5000
host: MallocManaged+init: 1.326028
cublasSgemm: 0.002031
host: access all arrays: 0.000110
host: access all arrays a second time: 0.000031
host: free: 0.028555
total: 1.911501
jetbot@jetbot:~/cuda-benchmarks$ ./gemmManagedPrefetch 5000
host: MallocManaged+init: 1.354017
cublasSgemm: 0.004661
host: access all arrays: 0.000067
host: access all arrays a second time: 0.000033
host: free: 0.029346
total: 1.933199
```